### PR TITLE
Change elasticsearch data directory permissions when container starts

### DIFF
--- a/hoover.nomad
+++ b/hoover.nomad
@@ -7,6 +7,7 @@ job "hoover" {
       driver = "docker"
       config {
         image = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4"
+        args = ["/bin/sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data && echo chown done && /usr/local/bin/docker-entrypoint.sh"]
         volumes = [
           "__LIQUID_VOLUMES__/hoover/es/data:/usr/share/elasticsearch/data",
         ]


### PR DESCRIPTION
After this we should be able to remove all `chown -R 1000:1000` lines from the [installation manual](https://hackmd.io/MeBET7lQSd2mBOv7vlhwWw#).