### PR TITLE
Clone & nuke hoover and liquidinvestigations repos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -133,3 +133,22 @@ cd /vagrant
 [Vagrant]: https://www.vagrantup.com
 [libvirt driver]: https://github.com/vagrant-libvirt/vagrant-libvirt
 [installing vagrant]: https://www.vagrantup.com/docs/installation/
+
+
+# Working on components
+
+In order to work on Hoover Search, Hoover Snoop, or Liquid Core, first clone the repositories:
+```shell
+cd repos
+./clone.sh https  # or ./clone.sh ssh, based on preference
+```
+
+After that, set this flag in your configuration:
+
+```ini
+[liquid]
+...
+mount_local_repos = true
+```
+
+Be sure to clone 

--- a/collection.nomad
+++ b/collection.nomad
@@ -93,6 +93,7 @@ job "collection-${name}" {
         image = "liquidinvestigations/hoover-snoop2"
         args = ["./manage.py", "runworkers"]
         volumes = [
+          ${hoover_snoop2_repo}
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}/data:/opt/hoover/snoop/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",
@@ -144,6 +145,7 @@ job "collection-${name}" {
       config {
         image = "liquidinvestigations/hoover-snoop2"
         volumes = [
+          ${hoover_snoop2_repo}
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}/data:/opt/hoover/snoop/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",

--- a/hoover.nomad
+++ b/hoover.nomad
@@ -71,6 +71,7 @@ job "hoover" {
       config {
         image = "liquidinvestigations/hoover-search"
         volumes = [
+          ${hoover_search_repo}
           "${liquid_volumes}/hoover-ui/build:/opt/hoover/ui/build",
         ]
         port_map {

--- a/liquid.nomad
+++ b/liquid.nomad
@@ -8,6 +8,7 @@ job "liquid" {
       config {
         image = "liquidinvestigations/core"
         volumes = [
+          ${liquidinvestigations_core_repo}
           "${liquid_volumes}/liquid/core/var:/app/var",
         ]
         labels {

--- a/liquid.py
+++ b/liquid.py
@@ -82,6 +82,12 @@ liquid_debug = get_config(
     '',
 )
 
+mount_local_repos = 'false' != get_config(
+    'LIQUID_MOUNT_LOCAL_REPOS',
+    'liquid.mount_local_repos',
+    'false',
+)
+
 liquid_volumes = get_config(
     'LIQUID_VOLUMES',
     'liquid.volumes',
@@ -246,6 +252,21 @@ def set_collection_defaults(name, settings):
 def set_volumes_paths(substitutions={}):
     substitutions['liquid_volumes'] = liquid_volumes
     substitutions['liquid_collections'] = liquid_collections
+
+    pwd = os.path.realpath(os.path.dirname(__file__))
+    repos = [
+        ('hoover', 'snoop2', '/opt/hoover/snoop'),
+        ('hoover', 'search', '/opt/hoover/search'),
+        ('liquidinvestigations', 'core', '/app'),
+    ]
+    for (org, repo, target_path) in repos:
+        repo_path = os.path.join(pwd, 'repos', org, repo)
+        repo_volume_line = (f'"{repo_path}:{target_path}",\n')
+        key = f'{org}_{repo}_repo'
+        if mount_local_repos:
+            substitutions[key] = repo_volume_line
+        else:
+            substitutions[key] = ''
     return substitutions
 
 

--- a/repos/.gitignore
+++ b/repos/.gitignore
@@ -1,0 +1,2 @@
+/liquidinvestigations
+/hoover

--- a/repos/clone.sh
+++ b/repos/clone.sh
@@ -5,9 +5,9 @@ for repo in hoover/snoop2 hoover/search liquidinvestigations/core; do
     echo $repo
     mkdir -p $repo
     if [ "$1" == 'ssh' ]; then
-            git clone "https://github.com/$repo.git" $repo
-    elif [ "$1" == 'https' ]; then
             git clone "git@github.com:$repo.git" $repo
+    elif [ "$1" == 'https' ]; then
+            git clone "https://github.com/$repo.git" $repo
     else
             set +x
             echo "Usage: $0 https - clone repos with https"

--- a/repos/clone.sh
+++ b/repos/clone.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+
+for repo in hoover/snoop2 hoover/search liquidinvestigations/core; do
+    echo $repo
+    mkdir -p $repo
+    if [ $1 -eq 'ssh' ]; then
+            git clone "https://github.com/$repo.git" $repo
+    elif [ $1 -eq 'https' ]; then
+            git clone "git@github.com:$repo.git" $repo
+    else
+            set +x
+            echo "Usage: $0 https - clone repos with https"
+            echo "       $0 ssh   - clone repos with ssh"
+            exit 1
+    fi
+done

--- a/repos/clone.sh
+++ b/repos/clone.sh
@@ -4,9 +4,9 @@ set -ex
 for repo in hoover/snoop2 hoover/search liquidinvestigations/core; do
     echo $repo
     mkdir -p $repo
-    if [ $1 -eq 'ssh' ]; then
+    if [ "$1" == 'ssh' ]; then
             git clone "https://github.com/$repo.git" $repo
-    elif [ $1 -eq 'https' ]; then
+    elif [ "$1" == 'https' ]; then
             git clone "git@github.com:$repo.git" $repo
     else
             set +x

--- a/repos/nuke.sh
+++ b/repos/nuke.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex
+
+exec find . -type d -depth 2 -delete

--- a/repos/nuke.sh
+++ b/repos/nuke.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-exec find . -type d -depth 2 -delete
+exec find . -type d -depth 2 -print0 | xargs -0 rm -rf


### PR DESCRIPTION
Permit working on hoover/search, hoover/snoop and liquidinvestigations/core.

First clone the repos:

```shell
cd repos
./clone.sh
```

Then add this config flag:
liquid.ini
```
[liquid]
mount_local_repos = true
```

Finally re-deploy.