### PR TITLE
Refactor the configuration logic

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,21 @@ cd /vagrant
 [installing vagrant]: https://www.vagrantup.com/docs/installation/
 
 
-# Working on components
+### Running custom jobs
+You can deploy your own jobs on the cluster. First, create a nomad job file,
+you can use one of the existing `.nomad` files as a starting point. Save it in
+the `local` folder, or outside the repository, so that it doesn't interfere
+with updates. Then add the job to `liquid.ini`:
+
+```ini
+[job:foo]
+template = local/foo.nomad
+```
+
+Afterwards, run `./liquid deploy`, which will send your job `foo` to nomad.
+
+
+### Working on components
 
 In order to work on Hoover Search, Hoover Snoop, or Liquid Core, first clone the repositories:
 ```shell

--- a/liquid.py
+++ b/liquid.py
@@ -32,10 +32,6 @@ class Configuration:
         self.ini = configparser.ConfigParser()
         self.ini.read('liquid.ini')
 
-        if 'extra_jobs' in self.ini:
-            for job, path in self.ini['extra_jobs'].items():
-                self.jobs.append((job, Path(path)))
-
         self.nomad_url = self.get(
             'NOMAD_URL',
             'cluster.nomad_url',
@@ -87,6 +83,10 @@ class Configuration:
 
             if cls == 'collection':
                 self.collections.append((name, self.ini[key]))
+
+            elif cls == 'job':
+                job_config = self.ini[key]
+                self.jobs.append((name, Path(job_config['template'])))
 
     def get(self, env_key, ini_path, default=None):
         if env_key and os.environ.get(env_key):

--- a/liquid.py
+++ b/liquid.py
@@ -20,85 +20,86 @@ LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
 log = logging.getLogger(__name__)
 log.setLevel(LOG_LEVEL)
 
-JOBS = [
-    (job, Path(f'{job}.nomad'))
-    for job in ['hoover', 'hoover-ui', 'liquid']
-]
 
-config = configparser.ConfigParser()
-config.read('liquid.ini')
+class Configuration:
+
+    def __init__(self):
+        self.jobs = [
+            (job, Path(f'{job}.nomad'))
+            for job in ['hoover', 'hoover-ui', 'liquid']
+        ]
+
+        self.ini = configparser.ConfigParser()
+        self.ini.read('liquid.ini')
+
+        if 'extra_jobs' in self.ini:
+            for job, path in self.ini['extra_jobs'].items():
+                self.jobs.append((job, Path(path)))
+
+        self.nomad_url = self.get(
+            'NOMAD_URL',
+            'cluster.nomad_url',
+            'http://127.0.0.1:4646',
+        )
+
+        self.consul_url = self.get(
+            'CONSUL_URL',
+            'cluster.consul_url',
+            'http://127.0.0.1:8500',
+        )
+
+        self.liquid_domain = self.get(
+            'LIQUID_DOMAIN',
+            'liquid.domain',
+            'localhost',
+        )
+
+        self.liquid_debug = self.get(
+            'LIQUID_DEBUG',
+            'liquid.debug',
+            '',
+        )
+
+        self.mount_local_repos = 'false' != self.get(
+            'LIQUID_MOUNT_LOCAL_REPOS',
+            'liquid.mount_local_repos',
+            'false',
+        )
+
+        self.liquid_volumes = self.get(
+            'LIQUID_VOLUMES',
+            'liquid.volumes',
+            str(Path(__file__).parent.resolve() / 'volumes'),
+        )
+
+        self.liquid_collections = self.get(
+            'LIQUID_COLLECTIONS',
+            'liquid.collections',
+            str(Path(__file__).parent.resolve() / 'collections'),
+        )
+
+        self.collections = []
+        for key in self.ini:
+            if ':' not in key:
+                continue
+
+            (cls, name) = key.split(':')
+
+            if cls == 'collection':
+                self.collections.append((name, self.ini[key]))
+
+    def get(self, env_key, ini_path, default=None):
+        if env_key and os.environ.get(env_key):
+            return os.environ[env_key]
+
+        (section_name, key) = ini_path.split('.')
+        if section_name in self.ini and key in self.ini[section_name]:
+            return self.ini[section_name][key]
+
+        return default
 
 
-if 'extra_jobs' in config:
-    for job, path in config['extra_jobs'].items():
-        JOBS.append((job, Path(path)))
-
-
-def get_collections():
-    sections = []
-    for section_name in config:
-        if ':' not in section_name:
-            continue
-
-        (label, collection_name) = section_name.split(':')
-        if label == 'collection' and collection_name:
-            sections.append((collection_name, config[section_name]))
-
-    return sections
-
-
-def get_config(env_key, ini_path, default=None):
-    if env_key and os.environ.get(env_key):
-        return os.environ[env_key]
-
-    (section_name, key) = ini_path.split('.')
-    if section_name in config and key in config[section_name]:
-        return config[section_name][key]
-
-    return default
-
-
-nomad_url = get_config(
-    'NOMAD_URL',
-    'cluster.nomad_url',
-    'http://127.0.0.1:4646',
-)
-
-consul_url = get_config(
-    'CONSUL_URL',
-    'cluster.consul_url',
-    'http://127.0.0.1:8500',
-)
-
-liquid_domain = get_config(
-    'LIQUID_DOMAIN',
-    'liquid.domain',
-    'localhost',
-)
-
-liquid_debug = get_config(
-    'LIQUID_DEBUG',
-    'liquid.debug',
-    '',
-)
-
-mount_local_repos = 'false' != get_config(
-    'LIQUID_MOUNT_LOCAL_REPOS',
-    'liquid.mount_local_repos',
-    'false',
-)
-
-liquid_volumes = get_config(
-    'LIQUID_VOLUMES',
-    'liquid.volumes',
-    str(Path(__file__).parent.resolve() / 'volumes'),
-)
-
-liquid_collections = get_config(
-    'LIQUID_COLLECTIONS',
-    'liquid.collections',
-    str(Path(__file__).parent.resolve() / 'collections'),
-)
+config = Configuration()
 
 
 def run(cmd):
@@ -197,8 +198,8 @@ class Consul(JsonApi):
 
 
 docker = Docker()
-nomad = Nomad(nomad_url)
-consul = Consul(consul_url)
+nomad = Nomad(config.nomad_url)
+consul = Consul(config.consul_url)
 
 
 def first(items, name_plural='items'):
@@ -250,8 +251,8 @@ def set_collection_defaults(name, settings):
 
 
 def set_volumes_paths(substitutions={}):
-    substitutions['liquid_volumes'] = liquid_volumes
-    substitutions['liquid_collections'] = liquid_collections
+    substitutions['liquid_volumes'] = config.liquid_volumes
+    substitutions['liquid_collections'] = config.liquid_collections
 
     pwd = os.path.realpath(os.path.dirname(__file__))
     repos = [
@@ -263,7 +264,7 @@ def set_volumes_paths(substitutions={}):
         repo_path = os.path.join(pwd, 'repos', org, repo)
         repo_volume_line = (f'"{repo_path}:{target_path}",\n')
         key = f'{org}_{repo}_repo'
-        if mount_local_repos:
+        if config.mount_local_repos:
             substitutions[key] = repo_volume_line
         else:
             substitutions[key] = ''
@@ -287,12 +288,14 @@ def get_job(hcl_path, substitutions={}):
 def deploy():
     """ Run all the jobs in nomad. """
 
-    consul.set_kv('liquid_domain', liquid_domain)
-    consul.set_kv('liquid_debug', liquid_debug)
+    consul.set_kv('liquid_domain', config.liquid_domain)
+    consul.set_kv('liquid_debug', config.liquid_debug)
 
-    jobs = [(job, get_job(path)) for job, path in JOBS]
-    jobs.extend([(f'collection-{name}', get_collection_job(name, settings))
-                 for name, settings in get_collections()])
+    jobs = [(job, get_job(path)) for job, path in config.jobs]
+    jobs.extend(
+        (f'collection-{name}', get_collection_job(name, settings))
+        for name, settings in config.collections
+    )
 
     for job, hcl in jobs:
         log.info('Starting %s...', job)
@@ -302,7 +305,8 @@ def deploy():
 def halt():
     """ Stop all the jobs in nomad. """
 
-    jobs = [j for j, _ in JOBS] + [f'collection-{name}' for name, _ in get_collections()]
+    jobs = [j for j, _ in config.jobs]
+    jobs.extend(f'collection-{name}' for name, _ in config.collections)
     for job in jobs:
         log.info('Stopping %s...', job)
         nomad.stop(job)


### PR DESCRIPTION
This patch encapsulates the configuration resolution as a class. It also changes the way custom jobs are defined - instead of listing them in an `extra_jobs` setting, they are now defined as separate sections, e.g.

```ini
[job:foo]
template = local/foo.nomad
```
