### PR TITLE
Forward admin dashboards to authenticated location  "https://admin.<domain>/<app>/"

### DIFF
--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -32,6 +32,11 @@ core_auth_apps = [
             '/accounts/oauth2-exchange/'
         ),
     },
+    {
+        'name': 'admin',
+        'vault_path': 'admin/auth.oauth2',
+        'callback': f'http://admin.{config.liquid_domain}/__auth/callback',
+    },
 ]
 
 
@@ -115,6 +120,7 @@ def deploy():
         'liquid/core.django',
         'hoover/search.django',
         'authdemo/auth.django',
+        'admin/auth.django',
     ]
 
     for path in vault_secret_keys:

--- a/liquid_node/jobs.py
+++ b/liquid_node/jobs.py
@@ -34,6 +34,7 @@ def set_volumes_paths(substitutions={}):
     substitutions['check_interval'] = config.check_interval
     substitutions['check_timeout'] = config.check_timeout
     substitutions['consul_socket'] = os.path.realpath(config.consul_socket)
+    substitutions['nomad_url'] = config.nomad_url
 
     substitutions['https_enabled'] = config.https_enabled
     if config.https_enabled:

--- a/liquid_node/vault.py
+++ b/liquid_node/vault.py
@@ -34,6 +34,7 @@ class Vault(JsonApi):
             raise
 
     def set(self, path, payload):
+        log.debug('vault set liquid/%s', path)
         return self.put(f'liquid/{path}', payload)
 
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -23,9 +23,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: 'provision-cluster.sh'
 
   # liquid node
-  config.vm.synced_folder "..", "/opt/node", type: "rsync",
-    rsync__exclude: [".vagrant/", ".git/", "__pycache__/",
-                     "liquid.ini", "venv/", "volumes/", "collections/"]
   config.vm.provision :file, source: liquid_ini, destination: '/tmp/vagrant-liquid.ini'
   config.vm.provision :shell, path: 'provision-liquid.sh'
 
@@ -41,6 +38,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |virtualbox, override|
     virtualbox.memory = 8192
     virtualbox.cpus = 2
+    override.vm.synced_folder "..", "/opt/node"
   end
 
   config.vm.provider :digital_ocean do |digital_ocean, override|
@@ -52,6 +50,9 @@ Vagrant.configure("2") do |config|
     override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
     override.nfs.functional = false
     override.ssh.private_key_path = ENV['DO_SSH_PRIVATE_KEY_PATH'] || '~/.ssh/id_rsa'
+    override.vm.synced_folder "..", "/opt/node", type: "rsync",
+      rsync__exclude: [".vagrant/", ".git/", "__pycache__/",
+                       "liquid.ini", "venv/", "volumes/", "collections/"]
 
     do_provision_env = {}
     if do_seppuku
@@ -78,6 +79,7 @@ Vagrant.configure("2") do |config|
     override.vm.box = "generic/ubuntu1804"
     libvirt.memory = 8192
     libvirt.cpus = 2
+    override.vm.synced_folder "..", "/opt/node"
   end
 
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -30,10 +30,10 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, path: custom_sh
   end
 
-  config.vm.network :forwarded_port, guest: 80, host: 1380, host_ip: "127.0.0.1"
-  config.vm.network :forwarded_port, guest: 4646, host: 14646, host_ip: "127.0.0.1"
-  config.vm.network :forwarded_port, guest: 8500, host: 18500, host_ip: "127.0.0.1"
-  config.vm.network :forwarded_port, guest: 8200, host: 18200, host_ip: "127.0.0.1"
+  config.vm.network :forwarded_port, guest: 80  , guest_ip: "10.66.60.1", host: 1380 , host_ip: "127.0.0.1"
+  config.vm.network :forwarded_port, guest: 4646, guest_ip: "10.66.60.1", host: 14646, host_ip: "127.0.0.1"
+  config.vm.network :forwarded_port, guest: 8500, guest_ip: "10.66.60.1", host: 18500, host_ip: "127.0.0.1"
+  config.vm.network :forwarded_port, guest: 8200, guest_ip: "10.66.60.1", host: 18200, host_ip: "127.0.0.1"
 
   config.vm.provider :virtualbox do |virtualbox, override|
     virtualbox.memory = 8192

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, path: custom_sh
   end
 
-  config.vm.network :forwarded_port, guest: 80  , guest_ip: "10.66.60.1", host: 1380 , host_ip: "127.0.0.1"
+  config.vm.network :forwarded_port, guest: 80  , guest_ip: "10.66.60.1", host: 1380, host_ip: "127.0.0.1"
   config.vm.network :forwarded_port, guest: 4646, guest_ip: "10.66.60.1", host: 14646, host_ip: "127.0.0.1"
   config.vm.network :forwarded_port, guest: 8500, guest_ip: "10.66.60.1", host: 18500, host_ip: "127.0.0.1"
   config.vm.network :forwarded_port, guest: 8200, guest_ip: "10.66.60.1", host: 18200, host_ip: "127.0.0.1"

--- a/vagrant/provision-cluster.sh
+++ b/vagrant/provision-cluster.sh
@@ -32,6 +32,7 @@ cat > /tmp/vagrant-boot-cluster.conf <<EOF
 user = root
 command = /opt/cluster/examples/network.sh
 autorestart = false
+redirect_stderr = true
 EOF
 sudo cp /tmp/vagrant-boot-cluster.conf /etc/supervisor/conf.d/boot-cluster.conf
 


### PR DESCRIPTION
This won't be easy to do as Nomad, Consul and Vault don't support adding a prefix to their UI. Their pages are hardcoded to work on `/ui/`.

Also, we'd need to expand this patch to create additional containers that run snoop and hoover admin sites on different domains with different global prefixes (all set through waitress-serve).
