### PR TITLE
Do `git pull` after `liquid halt`

### DIFF
--- a/vagrant/deploy-demo
+++ b/vagrant/deploy-demo
@@ -6,14 +6,16 @@ curl https://get.docker.com/ | sh -
 git --version
 docker --version
 
-git fetch -a
-git checkout master
-git pull
-
 pip install -r requirements.txt
 python --version
 python liquid.py alloc drone drone
 sleep 5
+
 python liquid.py halt
 sleep 13
+
+git fetch -a
+git checkout master
+git pull
+
 python liquid.py deploy


### PR DESCRIPTION
The old version is in a better position to tear itself down, so let's give it a fair chance.