### PR TITLE
Use a less obvious admin username

### DIFF
--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -177,7 +177,7 @@ def deploy():
         ensure_secret_key(f'collections/{name}/snoop.django')
 
     ensure_secret('rocketchat/adminuser', lambda: {
-        'username': 'admin',
+        'username': 'rocketchatadmin',
         'pass': random_secret(64),
     })
 


### PR DESCRIPTION
So that it doesn't clash with the liquiddemo.org admin account.

Fixes https://github.com/liquidinvestigations/node/issues/89