### PR TITLE
development repositories mount fixes

### DIFF
--- a/liquid_node/configuration.py
+++ b/liquid_node/configuration.py
@@ -43,17 +43,13 @@ class Configuration:
 
         self.mount_local_repos = self.ini.getboolean('liquid', 'mount_local_repos', fallback=False)
 
-        self.hoover_repos_path = self.ini.get(
-            'liquid',
-            'hoover_repos_path',
-            fallback=str((self.root / 'repos' / 'hoover').resolve())
-        )
+        hoover_repos_path = self.ini.get('liquid', 'hoover_repos_path',
+                                         fallback=str((self.root / 'repos' / 'hoover')))
+        self.hoover_repos_path = str(Path(hoover_repos_path).resolve())
 
-        self.liquidinvestigations_repos_path = self.ini.get(
-            'liquid',
-            'liquidinvestigations_repos_path',
-            fallback=str((self.root / 'repos' / 'liquidinvestigations').resolve())
-        )
+        li_repos_path = self.ini.get('liquid', 'liquidinvestigations_repos_path',
+                                     fallback=str((self.root / 'repos' / 'liquidinvestigations')))
+        self.liquidinvestigations_repos_path = str(Path(li_repos_path).resolve())
 
         self.liquid_volumes = self.ini.get('liquid', 'volumes', fallback=str(self.root / 'volumes'))
 

--- a/liquid_node/jobs.py
+++ b/liquid_node/jobs.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import jinja2
 
@@ -69,13 +70,14 @@ def set_volumes_paths(substitutions={}):
     }
 
     for repo, repo_config in repos.items():
-        repo_volume_line = (f"\"{repo_config['local']}:{repo_config['target']}\",\n")
         key = f"{repo_config['org']}_{repo}_repo"
 
+        substitutions[key] = ''
         if config.mount_local_repos:
-            substitutions[key] = repo_volume_line
-        else:
-            substitutions[key] = ''
+            if Path(repo_config['local']).is_dir():
+                substitutions[key] = f"\"{repo_config['local']}:{repo_config['target']}\",\n"
+            else:
+                log.warn(f'Invalid repo path "{repo_config["local"]}"')
 
     return substitutions
 


### PR DESCRIPTION
- allow relative paths (previously the mount paths had to be absolute)
- log warning when a repository path did not exist and do not mount it