### PR TITLE
Use authproxy for Rocket.Chat

### DIFF
--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -45,8 +45,13 @@ core_auth_apps = [
         'callback': f'{app_url("dokuwiki")}/__auth/callback',
     },
     {
-        'name': 'rocketchat',
+        'name': 'rocketchat-authproxy',
         'vault_path': 'rocketchat/auth.oauth2',
+        'callback': f'{app_url("rocketchat")}/__auth/callback',
+    },
+    {
+        'name': 'rocketchat-app',
+        'vault_path': 'rocketchat/app.oauth2',
         'callback': f'{app_url("rocketchat")}/_oauth/liquid',
     },
     {

--- a/templates/rocketchat.nomad
+++ b/templates/rocketchat.nomad
@@ -80,7 +80,7 @@ job "rocketchat" {
           {{- end }}
           OVERWRITE_SETTING_Accounts_OAuth_Custom-Liquid-authorize_path=${config.liquid_http_protocol}://${liquid_domain}/o/authorize/
           OVERWRITE_SETTING_Accounts_OAuth_Custom-Liquid-scope=read
-          {{- with secret "liquid/rocketchat/auth.oauth2" }}
+          {{- with secret "liquid/rocketchat/app.oauth2" }}
             OVERWRITE_SETTING_Accounts_OAuth_Custom-Liquid-id={{.Data.client_id}}
             OVERWRITE_SETTING_Accounts_OAuth_Custom-Liquid-secret={{.Data.client_secret}}
           {{- end }}
@@ -119,10 +119,6 @@ job "rocketchat" {
       service {
         name = "rocketchat-app"
         port = "web"
-        tags = [
-          "traefik.enable=true",
-          "traefik.frontend.rule=Host:rocketchat.${liquid_domain}",
-        ]
         check {
           name = "rocketchat alive on http"
           initial_status = "critical"
@@ -138,7 +134,7 @@ job "rocketchat" {
     }
   }
 
-  ${- '' and authproxy_group(
+  ${- authproxy_group(
       'rocketchat',
       host='rocketchat.' + liquid_domain,
       upstream='rocketchat-app',


### PR DESCRIPTION
* Users have to log in twice, but it's just clicking on buttons, not entering credentials, so it's pretty painless.
* If `foo` is logged in and chatting in rocketchat, and the person logs out from liquid, then logs in with a different account `bar` in the same browser, rocketchat will still believe that `foo` was logged in, because nobody automatically logged him out from rocketchat. https://github.com/liquidinvestigations/node/issues/105