### PR TITLE
increase server_name_hash_bucket_size to 128

### DIFF
--- a/templates/hoover.nomad
+++ b/templates/hoover.nomad
@@ -242,6 +242,7 @@ job "hoover" {
               {{- end }}
             {{- end }}
           {{- end }}
+          server_names_hash_bucket_size 128;
           EOF
         destination = "local/collections.conf"
       }


### PR DESCRIPTION
A spiegel VM of mine has a long name and nginx was exiting due to an error about the `server_name_hash_bucket_size `