### PR TITLE
importfromdockersetup: Don't overwrite ini file; link collections too

### DIFF
--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -377,8 +377,8 @@ def importfromdockersetup(path, method='link'):
     import_index(docker_setup, method)
 
     add_collections_ini(collections)
-
-    deploy()
+    print()
+    print('After adding the lines, re-run "./liquid deploy"')
 
 
 def shell(name, *args):

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -107,6 +107,6 @@ def import_collection(name, settings, docker_setup, method='copy'):
 
 
 def add_collections_ini(collections):
-    print('Add the following lines to your liquid.ini:')
+    print('\nAdd the following lines to your liquid.ini:\n')
     for name in collections:
         print(f'[collection:{name.lower()}]')

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -103,7 +103,10 @@ def import_collection(name, settings, docker_setup, method='copy'):
     log.info(f'Importing the collection "{name}" source files')
     collection_src = docker_setup / 'collections' / name
     collection_dst = Path(config.liquid_collections) / node_name
-    import_dir(collection_src, collection_dst, method)
+    if collection_dst.exists():
+        log.warning(f'Skipping source collection {name}, it already exists')
+    else:
+        import_dir(collection_src, collection_dst, method)
 
 
 def add_collections_ini(collections):

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -102,7 +102,7 @@ def import_collection(name, settings, docker_setup, method='copy'):
     # link original collection data
     log.info(f'Importing the collection "{name}" source files')
     collection_src = docker_setup / 'collections' / name
-    collection_dst = config.liquid_collections / node_name
+    collection_dst = Path(config.liquid_collections) / node_name
     import_dir(collection_src, collection_dst, method)
 
 

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -99,10 +99,14 @@ def import_collection(name, settings, docker_setup, method='copy'):
     log.info(f'Importing the collection "{name}" blobs dir from docker-setup to node..')
     import_dir(blob_src, blob_dst, method)
 
+    # link original collection data
+    log.info(f'Importing the collection "{name}" source files')
+    collection_src = docker_setup / 'collections' / name
+    collection_dst = config.liquid_collections / node_name
+    import_dir(collection_src, collection_dst, method)
+
 
 def add_collections_ini(collections):
+    print('Add the following lines to your liquid.ini:')
     for name in collections:
-        config.ini.add_section(f'collection:{name.lower()}')
-    ini_path = config.root / 'liquid.ini'
-    with ini_path.open(mode='w') as ini_file:
-        config.ini.write(ini_file)
+        print(f'[collection:{name.lower()}]')


### PR DESCRIPTION
Simplify migrating:

- don't overwrite liquid.ini, just ask the user to edit it
- link/copy/move the collection source data too