### PR TITLE
wait for env vars initialisation in the collection services

### DIFF
--- a/templates/_lib.hcl
+++ b/templates/_lib.hcl
@@ -91,3 +91,24 @@ ephemeral_disk {
     }
   }
 {%- endmacro %}
+
+
+{%- macro wait_env_vars_script(vars, command, attempts=10, delay=10) %}
+  data = <<-EOF
+  #!/bin/bash
+  set -ex
+  for i in $(seq 1 ${attempts}); do
+    missing=false
+    for v in $vars; do
+      {% raw %}
+      echo "$v=${!v}"
+      [ -z "${!v}" ] && missing=true
+      {% endraw %}
+    done
+    ! $missing && break
+    echo "incomplete configuration!"
+    sleep ${delay}
+  done
+  exec ${command}
+  EOF
+{%- endmacro %}


### PR DESCRIPTION
The snoop api and workers services keep being restarted until the environment var are set (after the corresponding services started). This script waits for the env vars to be set without exiting, reduces the processor usage.