### PR TITLE
allow only hoover jobs to be started

### DIFF
--- a/liquid_node/configuration.py
+++ b/liquid_node/configuration.py
@@ -30,11 +30,14 @@ class Configuration:
         self.root = Path(__file__).parent.parent.resolve()
         self.templates = self.root / 'templates'
 
-        self.jobs = [
+        self.hoover_jobs = [
             liquid.Liquid(),
             hoover.Hoover(),
             hoover.Ui(),
             hoover.Migrate(),
+        ]
+
+        self.jobs = self.hoover_jobs + [
             dokuwiki.Dokuwiki(),
             dokuwiki.Migrate(),
             rocketchat.Rocketchat(),


### PR DESCRIPTION
For dev purposes I need to be able to start LI faster, without using so many resources. When working on search and snoop it's enough to start only liquid, hoover and collections jobs.