### PR TITLE
Remove symlinks creation from vagrant/provision-liquid.sh

### DIFF
--- a/vagrant/provision-liquid.sh
+++ b/vagrant/provision-liquid.sh
@@ -7,17 +7,9 @@ echo "Installing liquid" > /dev/null
 cd /opt/node
 sudo chown -R vagrant: .
 
-if ! [ -e volumes ]; then
-  mkdir -p /opt/var/node/volumes
-  rm -f volumes
-fi
-
-if ! [ -e collections ]; then
-  mkdir -p /opt/var/node/collections
-  rm -f collections
-fi
-
-if ! [ -e collections/testdata ]; then
+mkdir volumes
+mkdir collections
+if ! [ -d collections/testdata ]; then
   git clone https://github.com/hoover/testdata collections/testdata
 fi
 

--- a/vagrant/provision-liquid.sh
+++ b/vagrant/provision-liquid.sh
@@ -10,13 +10,11 @@ sudo chown -R vagrant: .
 if ! [ -e volumes ]; then
   mkdir -p /opt/var/node/volumes
   rm -f volumes
-  ln -s /opt/var/node/volumes
 fi
 
 if ! [ -e collections ]; then
   mkdir -p /opt/var/node/collections
   rm -f collections
-  ln -s /opt/var/node/collections
 fi
 
 if ! [ -e collections/testdata ]; then


### PR DESCRIPTION
When running `vagrant up --provider=vmck` an error would show up saying that a symlink can't be synced through rsync, but there was no point in having synced symlinks.