### PR TITLE
Increase Rocket.Chat memory from 700M to 1.5G

### DIFF
--- a/templates/rocketchat.nomad
+++ b/templates/rocketchat.nomad
@@ -115,7 +115,7 @@ job "rocketchat" {
         destination = "local/main.js"
       }
       resources {
-        memory = 800
+        memory = 1500
         cpu = 400
         network {
           mbits = 1


### PR DESCRIPTION
Rocketchat is getting kicked out of traefik intermittently (404 errors), maybe healthchecks are failing because of low memory, now that it has nonzero users. Let's be generous with it.