### PR TITLE
Importcollection and Exportcollection

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -222,6 +222,9 @@ When using the `copy` method, the import will take longer.
 
 ### Importing and export single collections
 
+_**note:**_ Since directories might have been created by the docker daemon instead of a user,
+root privileges might be necessary.
+
 #### Exporting
 Liquid has to be deployed in order to export collections. When deployed, run
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -223,7 +223,7 @@ When using the `copy` method, the import will take longer.
 ### Importing and export single collections
 
 #### Exporting
-Liquid has to be deployed in order to export collections. When deployed, run 
+Liquid has to be deployed in order to export collections. When deployed, run
 ```
 ./liquid exportcollection <collection_name>
 ```
@@ -236,10 +236,10 @@ you need paths to the following data in order to import a collection:
 - index: a `.tgz` archive containing the index
 run the following command:
 ```
-./liquid importcollection <collection_name> <database_path> <blobs_path> <index_path> [method] 
+./liquid importcollection <collection_name> <database_path> <blobs_path> <index_path> [method]
 ```
 You can also specify whether data is moved, copied or linked by specifying the method.
-As of now, this is a positional argument, so put `method=copy/link/move` at the end of your command 
+As of now, this is a positional argument, so put `method=copy/link/move` at the end of your command
 
 ### Debugging
 

--- a/Readme.md
+++ b/Readme.md
@@ -237,9 +237,9 @@ you need paths to the following data in order to import a collection:
 run the following command:
 ```
 ./liquid importcollection <collection_name> <database_path> <blobs_path> <index_path> [method] 
-
+```
 You can also specify whether data is moved, copied or linked by specifying the method.
-As of now, this is a positional argument, so put `method='copy/link/move` at the end of your command 
+As of now, this is a positional argument, so put `method=copy/link/move` at the end of your command 
 
 ### Debugging
 

--- a/Readme.md
+++ b/Readme.md
@@ -220,6 +220,27 @@ The `method` is optional. The default value is `link`, while the possible values
 
 When using the `copy` method, the import will take longer.
 
+### Importing and export single collections
+
+#### Exporting
+Liquid has to be deployed in order to export collections. When deployed, run 
+```
+./liquid exportcollection <collection_name>
+```
+The exported collection data is stored in `<collections_directory>/exported/<collection_name`
+
+#### Importing
+you need paths to the following data in order to import a collection:
+- database: the folder must contain a subfolder called data, containing the database
+- blobs: the folder contains the blobs
+- index: a `.tgz` archive containing the index
+run the following command:
+```
+./liquid importcollection <collection_name> <database_path> <blobs_path> <index_path> [method] 
+
+You can also specify whether data is moved, copied or linked by specifying the method.
+As of now, this is a positional argument, so put `method='copy/link/move` at the end of your command 
+
 ### Debugging
 
 Set the debug flag in `liquid.ini`:

--- a/Readme.md
+++ b/Readme.md
@@ -230,7 +230,7 @@ Liquid has to be deployed in order to export collections. When deployed, run
 ```
 ./liquid exportcollection <collection_name>
 ```
-The exported collection data is stored in `<collections_directory>/exported/<collection_name`
+The exported collection data is stored in `volumes/exports/<collection_name>`
 
 #### Importing
 you need paths to the following data in order to import a collection:

--- a/liquid.py
+++ b/liquid.py
@@ -45,6 +45,7 @@ def main():
         commands.initcollection,
         commands.deletecollection,
         commands.importcollection,
+        commands.exportcollection,
         commands.purge,
         commands.getsecret,
         commands.importfromdockersetup,

--- a/liquid.py
+++ b/liquid.py
@@ -44,6 +44,7 @@ def main():
         commands.halt,
         commands.initcollection,
         commands.deletecollection,
+        commands.importcollection,
         commands.purge,
         commands.getsecret,
         commands.importfromdockersetup,

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -524,10 +524,10 @@ def importcollection(name, path, method='copy'):
     blob_src = blobs
     blob_dst = collection_path / 'blobs'
     import_dir(blob_src, blob_dst, method=method)
-    (collection_path / 'index').mkdir()
-    # copy or link the index
-    index = Path(index).resolve(strict=True)
 
+    # copy or link the index
+    (collection_path / 'index').mkdir()
+    index = Path(index).resolve(strict=True)
     index_dst = collection_path / 'index' / f'{name}-index.tgz'
     import_file(index, index_dst, method=method)
 
@@ -547,7 +547,7 @@ def exportcollection(name):
     """
     if name not in config.collections:
         raise RuntimeError(f'Collection {name} does not exist in the liquid.ini file.')
-    export_path = Path(config.liquid_collections) / 'exported' / name
+    export_path = Path(config.liquid_volumes) / 'exports' / name
     if export_path.exists():
         if confirm(f'collection {name} already has exported files in {export_path}, overwrite?'):
             shutil.rmtree(export_path)
@@ -556,19 +556,19 @@ def exportcollection(name):
             exit()
     else:
         (export_path).mkdir(parents=True)
+    collection_volumes = Path(config.liquid_volumes) / 'collections' / name
     # copy the pg dir
-    database = Path(config.liquid_volumes) / 'collections' / name / 'pg'
+    database = collection_volumes / 'pg'
     pg_src = database
     pg_dst = export_path / 'pg'
     import_dir(pg_src, pg_dst, method='copy')
 
     # copy the blobs dir
-    blobs = Path(config.liquid_volumes) / 'collections' / name / 'blobs'
+    blobs = collection_volumes / 'blobs'
     blob_src = blobs
     blob_dst = export_path / 'blobs'
     import_dir(blob_src, blob_dst, method='copy')
 
-    log.info(f'found index for {name}, importing index instead of creating it')
     with gzip.open(export_path / f'{name}-index.tgz', "w") as index_file:
         docker.exec_(
             f'snoop-{name}-api',

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -486,14 +486,14 @@ def importcollection(name, database, blobs, index, method='copy'):
     if collection_path.exists():
         raise RuntimeError("collection path already exists, can't import")
     else:
-        (collection_path / 'pg').mkdir(parents=True)
+        (collection_path).mkdir(parents=True)
 
     # copy the pg dir
     database = Path(database).resolve(strict=True)
-    if not (database / 'PG_VERSION').exists():
+    if not (database / 'data' / 'PG_VERSION').exists():
         raise RuntimeError("database is not a valid Postgres database")
     pg_src = database
-    pg_dst = collection_path / 'pg' / 'data'
+    pg_dst = collection_path / 'pg'
     import_dir(pg_src, pg_dst, method=method)
 
     # copy the blobs dir

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -404,21 +404,17 @@ def initcollection(name):
     index_path = Path(config.liquid_volumes) / 'collections' / name / 'index' / f'{name}-index.tgz' 
     if index_path.is_file():
         log.info('found index, importing index instead of creating it')
-        docker.exec_(
-            f'snoop-{name}-api',
-            './manage.py', 'importindex',
-            '<', index_path,
-        )
+
     else:
         docker.exec_(f'snoop-{name}-api', './manage.py', 'initcollection')
-
-    docker.exec_(
-        'hoover-search',
-        './manage.py', 'addcollection', name,
-        '--index', name,
-        f'http://{nomad.get_address()}:8765/{name}/collection/json',
-        '--public',
-    )
+        #@TODO: has to be outside of the else clause in the end!
+        docker.exec_(
+            'hoover-search',
+            './manage.py', 'addcollection', name,
+            '--index', name,
+            f'http://{nomad.get_address()}:8765/{name}/collection/json',
+            '--public',
+        )
 
 
 def purge(force=False):

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -403,11 +403,11 @@ def initcollection(name):
         return
     index_path = Path(config.liquid_volumes) / 'collections' / name / 'index' / f'{name}-index.tgz' 
     if index_path.is_file():
-        log.info('found index, importing index instead of creating it')
+        log.info(f'found index for {name}, importing index instead of creating it')
         docker.exec_(
             '-i', f'snoop-{name}-api',
             './manage.py', 'importindex', '<',
-            index_path
+            str(index_path)
         )
     else:
         docker.exec_(f'snoop-{name}-api', './manage.py', 'initcollection')
@@ -512,6 +512,8 @@ def importcollection(name, database, blobs, index, method='copy' ):
         os.rename(index, index_path / f'{name}-index.tgz')
 
     log.info(f'Imported collection using method: {method}')
+    print('add the following line to liquid.ini')
+    print(f'[collection:{name}]')
 
 
 def importfromdockersetup(path, method='link'):
@@ -558,10 +560,10 @@ def shell(name, *args):
     docker.shell(name, *args)
 
 
-def dockerexec(name, *args):
+def dockerexec(*args):
     """Run `docker exec` in a container tagged with liquid_task=`name`"""
 
-    docker.exec_(name, *args)
+    docker.exec_(*args)
 
 
 def getsecret(path=None):

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -6,6 +6,7 @@ import os
 import base64
 import json
 import shutil
+import tarfile
 import gzip
 
 from liquid_node.collections import push_collections_titles
@@ -551,24 +552,31 @@ def exportcollection(name):
     if export_path.exists():
         if confirm(f'collection {name} already has exported files in {export_path}, overwrite?'):
             shutil.rmtree(export_path)
+            export_path.mkdir(parents=True)
         else:
             log.info(f'exiting and not overwriting data for {name}')
             exit()
     else:
-        (export_path).mkdir(parents=True)
+        export_path.mkdir(parents=True)
     collection_volumes = Path(config.liquid_volumes) / 'collections' / name
-    # copy the pg dir
-    database = collection_volumes / 'pg'
-    pg_src = database
-    pg_dst = export_path / 'pg'
-    import_dir(pg_src, pg_dst, method='copy')
+
+    # dumping the database
+    with gzip.open(export_path / 'pg_dump.tgz', "w") as pg_dump:
+        docker.exec_(
+            f'snoop-{name}-pg',
+            'pg_dump', '-Ox', '-U', 'snoop', 'snoop',
+            stdout=pg_dump, interactive=True
+        )
+    log.info(f'dumped database to {export_path}')
 
     # copy the blobs dir
     blobs = collection_volumes / 'blobs'
-    blob_src = blobs
-    blob_dst = export_path / 'blobs'
-    import_dir(blob_src, blob_dst, method='copy')
+    blobs_tar = tarfile.open(export_path / "blobs.tgz", "w:gz")
+    blobs_tar.add(blobs, arcname='blobs')
+    blobs_tar.close()
+    log.info(f'dumped blobs to {export_path}')
 
+    # copy the index
     with gzip.open(export_path / f'{name}-index.tgz', "w") as index_file:
         docker.exec_(
             f'snoop-{name}-api',

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -404,11 +404,12 @@ def initcollection(name):
     index_path = Path(config.liquid_volumes) / 'collections' / name / 'index' / f'{name}-index.tgz' 
     if index_path.is_file():
         log.info(f'found index for {name}, importing index instead of creating it')
-        docker.exec_(
-            '-i', f'snoop-{name}-api',
-            './manage.py', 'importindex', '<',
-            str(index_path)
-        )
+        with open(index_path, "r") as index_file:
+            docker.exec_(
+                '-i', f'snoop-{name}-api',
+                './manage.py', 'importindex',
+                stdin=index_file
+            )
     else:
         docker.exec_(f'snoop-{name}-api', './manage.py', 'initcollection')
     docker.exec_(

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -41,15 +41,15 @@ class Docker:
         docker_exec_cmd += [container_id] + list(additional_args or (['bash'] if tty else []))
         return docker_exec_cmd
 
-    def shell(self, name, *args,stdin=None, tty=False):
+    def shell(self, name, *args, stdin=None, stdout=None, tty=False):
         """Run the given command in a docker container tagged with liquid_task=`name`.
 
         The command output is redirected to the standard output and a tty is opened.
         """
-        run_fg(self.exec_command(name, *args, tty=True), stdin=stdin, shell=False)
+        run_fg(self.exec_command(name, *args, tty=True), stdin=stdin, stdout=stdout, shell=False)
 
-    def exec_(self, *args, stdin=None):
-        run_fg(self.exec_command(*args), stdin=stdin,shell=False)
+    def exec_(self, *args, stdin=None, stdout=None):
+        run_fg(self.exec_command(*args), stdin=stdin, stdout=stdout, shell=False)
 
 
 docker = Docker()

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -12,12 +12,13 @@ class Docker:
 
     def exec_command(self, *args, tty=False):
         """Prepare and return the command to run in a docker container tagged with
-        liquid_task=`name`.
+        liquid_task=`name`
         you can give the same flags to the command as to docker exec, at the beginning
         of your command. The first argument, which doesn't start with '-' is interpreted
         as the container name.
 
         :param name: the value of the liquid_task tag
+        :param tty: if true, instruct docker to allocate a pseudo-TTY and keep stdin open
         """
         additional_args = []
         name = ''

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -10,7 +10,7 @@ class Docker:
         out = run(f'docker ps -q {label_args}')
         return out.split()
 
-    def exec_command(self, name, *args, interactive=False,  tty=False):
+    def exec_command(self, name, *args, interactive=False, tty=False):
         """Prepare and return the command to run in a docker container tagged with
         liquid_task=`name`
         :param name: the value of the liquid_task tag
@@ -35,10 +35,12 @@ class Docker:
 
         The command output is redirected to the standard output and a tty is opened.
         """
-        run_fg(self.exec_command(name, *args, tty=True, interactive=True), stdin=stdin, stdout=stdout, shell=False)
+        run_fg(self.exec_command(name, *args, tty=True, interactive=True),
+               stdin=stdin, stdout=stdout, shell=False)
 
-    def exec_(self, name, *args, interactive=False,  tty=False, stdin=None, stdout=None):
-        run_fg(self.exec_command(name, *args, interactive=interactive, tty=tty), stdin=stdin, stdout=stdout, shell=False)
+    def exec_(self, name, *args, interactive=False, tty=False, stdin=None, stdout=None):
+        run_fg(self.exec_command(name, *args, interactive=interactive, tty=tty),
+               stdin=stdin, stdout=stdout, shell=False)
 
 
 docker = Docker()

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -13,12 +13,9 @@ class Docker:
     def exec_command(self, name, *args, interactive=False,  tty=False):
         """Prepare and return the command to run in a docker container tagged with
         liquid_task=`name`
-        you can give the same flags to the command as to docker exec, at the beginning
-        of your command. The first argument, which doesn't start with '-' is interpreted
-        as the container name.
-
         :param name: the value of the liquid_task tag
-        :param tty: if true, instruct docker to allocate a pseudo-TTY and keep stdin open
+        :param tty: if true, instruct docker to allocate a pseudo-TTY
+        :param interactive: if true docker will keep STDIN open
         """
 
         docker_exec_cmd = ['docker', 'exec']

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -23,13 +23,13 @@ class Docker:
         name = ''
         docker_exec_cmd = ['docker', 'exec']
         for arg in args:
-            if arg.startswith('-'):
-                docker_exec_cmd += [arg]
-            else:
-                if not name:
-                    name = arg
+            if not name:
+                if arg.startswith('-'):
+                    docker_exec_cmd += [arg]
                 else:
-                    additional_args += [arg]
+                    name = arg
+            else:
+                additional_args += [arg]
         if not name:
             raise TypeError('name must be set.')
 
@@ -41,15 +41,15 @@ class Docker:
         docker_exec_cmd += [container_id] + list(additional_args or (['bash'] if tty else []))
         return docker_exec_cmd
 
-    def shell(self, name, *args, tty=False):
+    def shell(self, name, *args,stdin=None, tty=False):
         """Run the given command in a docker container tagged with liquid_task=`name`.
 
         The command output is redirected to the standard output and a tty is opened.
         """
-        run_fg(self.exec_command(name, *args, tty=True), shell=False)
+        run_fg(self.exec_command(name, *args, tty=True), stdin=stdin, shell=False)
 
-    def exec_(self, *args):
-        run_fg(self.exec_command(*args), shell=False)
+    def exec_(self, *args, stdin=None):
+        run_fg(self.exec_command(*args), stdin=stdin,shell=False)
 
 
 docker = Docker()

--- a/liquid_node/docker.py
+++ b/liquid_node/docker.py
@@ -27,7 +27,7 @@ class Docker:
             docker_exec_cmd += ['-t']
         if interactive:
             docker_exec_cmd += ['-i']
-        docker_exec_cmd += [container_id] + list(args or (['bash'] if (tty and interactive) else []))
+        docker_exec_cmd += [container_id] + list(args)
         return docker_exec_cmd
 
     def shell(self, name, *args, stdin=None, stdout=None):

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import os
 from pathlib import Path
 
 from liquid_node.configuration import config
@@ -54,6 +55,18 @@ def import_dir(src, dst, method='link'):
     elif method == 'link':
         log.info(f'Linking {dst} to {src}')
         dst.symlink_to(src)
+
+def import_file(src, dst, method='link'):
+    if method == 'copy':
+        shutil.copy(src, dst, follow_symlinks=True)
+    elif method == 'link':
+        os.symlink(src, dst)
+    elif method == 'move':
+        os.rename(src, dst)
+    else:
+        raise RuntimeError(f'unknown method for importing file: {method}')
+    log.info(f'imported file from {src} to {dst} using method: {method}')
+
 
 
 def import_index(docker_setup, method):

--- a/liquid_node/import_from_docker.py
+++ b/liquid_node/import_from_docker.py
@@ -56,6 +56,7 @@ def import_dir(src, dst, method='link'):
         log.info(f'Linking {dst} to {src}')
         dst.symlink_to(src)
 
+
 def import_file(src, dst, method='link'):
     if method == 'copy':
         shutil.copy(src, dst, follow_symlinks=True)
@@ -66,7 +67,6 @@ def import_file(src, dst, method='link'):
     else:
         raise RuntimeError(f'unknown method for importing file: {method}')
     log.info(f'imported file from {src} to {dst} using method: {method}')
-
 
 
 def import_index(docker_setup, method):

--- a/liquid_node/process.py
+++ b/liquid_node/process.py
@@ -14,7 +14,7 @@ def run(cmd, **kwargs):
     return subprocess.check_output(cmd, **kwargs).decode('latin1')
 
 
-def run_fg(cmd, stdin=None, **kwargs):
+def run_fg(cmd, **kwargs):
     """Run the given command in a subprocess.
 
     The command output is redirected to the standard output and a tty is opened.
@@ -22,4 +22,4 @@ def run_fg(cmd, stdin=None, **kwargs):
 
     log.debug("+ %s", cmd)
     kwargs.setdefault('shell', True)
-    subprocess.check_call(cmd, **kwargs, stdin=stdin)
+    subprocess.check_call(cmd, **kwargs)

--- a/liquid_node/process.py
+++ b/liquid_node/process.py
@@ -14,7 +14,7 @@ def run(cmd, **kwargs):
     return subprocess.check_output(cmd, **kwargs).decode('latin1')
 
 
-def run_fg(cmd, **kwargs):
+def run_fg(cmd, stdin=None, **kwargs):
     """Run the given command in a subprocess.
 
     The command output is redirected to the standard output and a tty is opened.
@@ -22,4 +22,4 @@ def run_fg(cmd, **kwargs):
 
     log.debug("+ %s", cmd)
     kwargs.setdefault('shell', True)
-    subprocess.check_call(cmd, **kwargs)
+    subprocess.check_call(cmd, **kwargs, stdin=stdin)

--- a/templates/collection.nomad
+++ b/templates/collection.nomad
@@ -22,7 +22,6 @@ job "collection-${name}" {
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}:/opt/hoover/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",
-          "${liquid_volumes}/collections/${name}/index:/opt/hoover/index",
         ]
         port_map {
           flower = 5555
@@ -120,7 +119,6 @@ job "collection-${name}" {
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}:/opt/hoover/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",
-          "${liquid_volumes}/collections/${name}/index:/opt/hoover/index",
           "${liquid_volumes}/hoover/es/snapshots:/opt/hoover/es-snapshots"
         ]
         port_map {

--- a/templates/collection.nomad
+++ b/templates/collection.nomad
@@ -22,6 +22,7 @@ job "collection-${name}" {
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}:/opt/hoover/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",
+          "${liquid_volumes}/collections/${name}/index:/opt/hoover/index",
         ]
         port_map {
           flower = 5555
@@ -119,6 +120,8 @@ job "collection-${name}" {
           "${liquid_volumes}/gnupg:/opt/hoover/gnupg",
           "${liquid_collections}/${name}:/opt/hoover/collection",
           "${liquid_volumes}/collections/${name}/blobs:/opt/hoover/snoop/blobs",
+          "${liquid_volumes}/collections/${name}/index:/opt/hoover/index",
+          "${liquid_volumes}/hoover/es/snapshots:/opt/hoover/es-snapshots"
         ]
         port_map {
           http = 80

--- a/templates/hoover-deps.nomad
+++ b/templates/hoover-deps.nomad
@@ -10,9 +10,10 @@ job "hoover-deps" {
       driver = "docker"
       config {
         image = "docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4"
-        args = ["/bin/sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data && echo chown done && /usr/local/bin/docker-entrypoint.sh"]
+        args = ["/bin/sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data /opt/hoover/es-snapshots && echo chown done && /usr/local/bin/docker-entrypoint.sh"]
         volumes = [
           "${liquid_volumes}/hoover/es/data:/usr/share/elasticsearch/data",
+          "${liquid_volumes}/hoover/es/snapshots:/opt/hoover/es-snapshots"
         ]
         port_map {
           es = 9200
@@ -24,6 +25,7 @@ job "hoover-deps" {
       env {
         cluster.name = "hoover"
         ES_JAVA_OPTS = "-Xms${config.elasticsearch_heap_size}m -Xmx${config.elasticsearch_heap_size}m"
+        path.repo = "/opt/hoover/es-snapshots"
       }
       resources {
         memory = ${config.elasticsearch_memory_limit}


### PR DESCRIPTION
The PR adds an importcollection and exportcollection command to liquid and explains how to use them in the Readme.
It also tweaks the docker commands slightly, so that `dockerexec` can handle flags just like `docker exec` and so that one can pipe files into and out of the container (needed for import and export).
`initcollection` checks whether an index is stored at `<liquid_volumes/collections/<collection_name>/index/<collection_name>-index.tgz` and if so, imports the index instead of initializing the collection.