### PR TITLE
Agressive restarts for authproxy

### DIFF
--- a/templates/_lib.hcl
+++ b/templates/_lib.hcl
@@ -16,7 +16,12 @@ ephemeral_disk {
 
 {%- macro authproxy_group(name, host, upstream, threads=4, memory=150, user_header_template="{}") %}
   group "authproxy" {
-    ${ continuous_reschedule() }
+    restart {
+      interval = "1m"
+      attempts = 4
+      delay = "5s"
+      mode = "delay"
+    }
 
     task "web" {
       driver = "docker"


### PR DESCRIPTION
Authproxy should restart more aggressively. We run a limited number of them, and they are super lightweight (Flask apps with a couple of views), so it won't hurt performance much. I find myself waiting for nomad to reschedule authproxy often, and this should help.

I think these settings mean "Within a 1 minute window, allow 4 restarts, and wait 5 seconds before a restart. If that fails, instead of making a new alloc, reuse this one." Reference: https://www.nomadproject.io/docs/job-specification/restart.html

By the way, this is running on Rubidium right now, it's helping me debug Hypothesis.