### PR TITLE
Removed -q (currently not supported using Ubuntu)

### DIFF
--- a/liquid
+++ b/liquid
@@ -5,7 +5,7 @@ set -e
 cd "$(dirname ${BASH_SOURCE[0]})"
 
 # delete venv if outdated
-if ! shasum -cq venv/requirements.shasum; then
+if ! shasum -c venv/requirements.shasum; then
   rm -rf venv
 fi
 


### PR DESCRIPTION
Just to avoid the error message for QA and Production until we replace the liquid wrapper