### PR TITLE
fix drone secret key name for plugin

### DIFF
--- a/templates/drone.nomad
+++ b/templates/drone.nomad
@@ -28,7 +28,7 @@ job "drone" {
       template {
         data = <<-EOF
           {{- with secret "liquid/ci/drone.secret" }}
-            SECRET_KEY = {{.Data.secret_key | toJSON }}
+            DRONE_SECRET = {{.Data.secret_key | toJSON }}
           {{- end }}
         EOF
         destination = "local/drone.env"


### PR DESCRIPTION
1 commit https://github.com/drone/drone-vault/commit/309888e6035a7fa3ccb5bba5c3588c2433fec192
only latest docker tags https://hub.docker.com/r/drone/vault/tags
All history rewritten...
