### PR TITLE
Fix migration script file scan

### DIFF
--- a/templates/nextcloud-setup.sh
+++ b/templates/nextcloud-setup.sh
@@ -101,4 +101,4 @@ php occ app:disable updatenotification
 echo "Configuration done"
 
 # scan the filesystem in case there are files initially (redeploy e.g.)
-php occ files:scan
+php occ files:scan --all


### PR DESCRIPTION
php occ files:scan doesn't work without either --all or an user-id.