### PR TITLE
add check_restart for javascript servers

### DIFF
--- a/templates/codimd.nomad
+++ b/templates/codimd.nomad
@@ -95,6 +95,10 @@ job "codimd" {
           interval = "${check_interval}"
           timeout = "${check_timeout}"
         }
+        check_restart {
+          limit = 3
+          grace = "90s"
+        }
       }
     }
 

--- a/templates/rocketchat.nomad
+++ b/templates/rocketchat.nomad
@@ -143,6 +143,10 @@ job "rocketchat" {
             Host = ["rocketchat.${liquid_domain}"]
           }
         }
+        check_restart {
+          limit = 3
+          grace = "90s"
+        }
       }
     }
 


### PR DESCRIPTION
Because they randomly enter a `connection refused` state and stay there...