### PR TITLE
Set codimd port for the url

### DIFF
--- a/templates/codimd.nomad
+++ b/templates/codimd.nomad
@@ -35,6 +35,7 @@ job "codimd" {
         CMD_HOST = "0.0.0.0"
         CMD_PORT = "3000"
         CMD_DOMAIN = "codimd.${liquid_domain}"
+        CMD_URL_ADDPORT = "{% if config.https_enabled %}${ liquid_https_port }{% else %}${ liquid_http_port }{% endif %}"
         CMD_PROTOCOL_USESSL = "{% if config.https_enabled %}true{% else %}false{% endif %}"
         CMD_ALLOW_ORIGIN = "codimd.${liquid_domain}"
         CMD_USECDN = "false"


### PR DESCRIPTION
Apparently codimd generates URLs with port 3000 unless we set this.
