### PR TITLE
Update deploy timeouts

### DIFF
--- a/examples/liquid.ini
+++ b/examples/liquid.ini
@@ -121,9 +121,9 @@ wait_green_count = 10
 # liquid-core = liquidinvestigations/core:latest
 
 
-# Run a zipkin tracing system. Remove if not needed.
-[job:zipkin]
-template = templates/zipkin.nomad
+# Run a zipkin tracing system.
+; [job:zipkin]
+; template = templates/zipkin.nomad
 
 # Run a custom local job, see litterbox.py
 # [job:Cat]

--- a/examples/liquid.ini
+++ b/examples/liquid.ini
@@ -107,13 +107,15 @@ elasticsearch_data_node_count = 1
 ;default_app_status = on
 
 # Health check interval and timeout for all services
-check_interval = 30s
+# Increase check_interval to lower idle system load at the cost
+# of higher deploy times.
+check_interval = 16s
 check_timeout = 10s
 
 # Configure how to poll health when running `./liquid deploy`
-wait_max_sec = 600
+wait_max_sec = 660
 wait_poll_interval = 1
-wait_green_count = 10
+wait_green_count = 6
 
 
 [versions]

--- a/templates/nextcloud-migrate.nomad
+++ b/templates/nextcloud-migrate.nomad
@@ -54,9 +54,6 @@ job "nextcloud-migrate" {
       template {
         data = <<-EOF
         HTTP_PROTO = "${config.liquid_http_protocol}"
-        {{- range service "nextcloud-app" }}
-          NEXTCLOUD_INTERNAL_STATUS_URL = "http://{{.Address}}:{{.Port}}/status.php"
-        {{- end }}
         NEXTCLOUD_HOST = "nextcloud.{{ key "liquid_domain" }}"
         NEXTCLOUD_ADMIN_USER = "admin"
         {{- with secret "liquid/nextcloud/nextcloud.admin" }}

--- a/templates/nextcloud-setup.sh
+++ b/templates/nextcloud-setup.sh
@@ -2,19 +2,13 @@
 
 set -ex
 
-if [ -z "$NEXTCLOUD_INTERNAL_STATUS_URL" ]; then
-    echo "Missing NEXTCLOUD_INTERNAL_STATUS_URL - please wait for apache to boot up"
-    sleep 6
-    exit 1
-fi
-
 if [ -z "$MYSQL_HOST" ]; then
     echo "Missing MYSQL_HOST - please wait for the DB to spin up before running setup"
     sleep 6
     exit 1
 fi
 
-INSTALLED=$(curl --silent --header "Host: $NEXTCLOUD_HOST" $NEXTCLOUD_INTERNAL_STATUS_URL | jq .installed)
+INSTALLED=$(php /var/www/html/occ status --output=json | jq .installed)
 if [ "$INSTALLED" == "false" ]; then
     echo "Installing nextcloud"
 


### PR DESCRIPTION
To avoid CI timeouts like https://jenkins.liquiddemo.org/liquidinvestigations/node/1067/1/3 and reduce total CI runtime.