### PR TITLE
Unbashify script inside nomad template

### DIFF
--- a/templates/_lib.hcl
+++ b/templates/_lib.hcl
@@ -124,7 +124,7 @@ ephemeral_disk {
 {%- macro set_pg_password_template(username) %}
   template {
     data = <<-EOF
-    #!/bin/sh
+    #!/bin/bash
     set -e
     sed -i 's/host all all all trust/host all all all md5/' $PGDATA/pg_hba.conf
     psql -U ${username} -c "ALTER USER ${username} password '$POSTGRES_PASSWORD'"

--- a/templates/hoover-workers.nomad
+++ b/templates/hoover-workers.nomad
@@ -25,7 +25,7 @@ job "hoover-workers" {
       driver = "docker"
       config {
         image = "${config.image('hoover-snoop2')}"
-        args = ["sh", "/local/startup.sh"]
+        args = ["bash", "/local/startup.sh"]
         volumes = [
           ${hoover_snoop2_repo}
           "{% raw %}${meta.liquid_collections}{% endraw %}:/opt/hoover/collections",
@@ -56,7 +56,7 @@ job "hoover-workers" {
       }
       template {
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
           # exec tail -f /dev/null
           if  [ -z "$SNOOP_TIKA_URL" ] \

--- a/templates/hoover.nomad
+++ b/templates/hoover.nomad
@@ -22,7 +22,7 @@ job "hoover" {
 
       config {
         image = "${config.image('hoover-search')}"
-        args = ["sh", "/local/startup.sh"]
+        args = ["bash", "/local/startup.sh"]
         volumes = [
           ${hoover_search_repo}
           "{% raw %}${meta.liquid_volumes}{% endraw %}/hoover-ui/build:/opt/hoover/ui/build:ro",
@@ -46,7 +46,7 @@ job "hoover" {
 
       template {
         data = <<-EOF
-        #!/bin/sh
+        #!/bin/bash
         set -ex
         (
         set +x
@@ -150,7 +150,7 @@ job "hoover" {
       driver = "docker"
       config {
         image = "${config.image('hoover-snoop2')}"
-        args = ["sh", "/local/startup.sh"]
+        args = ["bash", "/local/startup.sh"]
         volumes = [
           ${hoover_snoop2_repo}
         ]
@@ -168,7 +168,7 @@ job "hoover" {
       }
       template {
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
           if  [ -z "$SNOOP_DB" ] \
                   || [ -z "$SNOOP_ES_URL" ] \
@@ -243,7 +243,7 @@ job "hoover" {
       driver = "docker"
       config {
         image = "${config.image('hoover-snoop2')}"
-        args = ["sh", "/local/startup.sh"]
+        args = ["bash", "/local/startup.sh"]
         volumes = [
           ${hoover_snoop2_repo}
         ]
@@ -251,7 +251,7 @@ job "hoover" {
       }
       template {
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
           if  [ -z "$SNOOP_DB" ] \
                   || [ -z "$SNOOP_ES_URL" ] \
@@ -324,7 +324,7 @@ job "hoover" {
       driver = "docker"
       config {
         image = "${config.image('hoover-snoop2')}"
-        args = ["sh", "/local/startup.sh"]
+        args = ["bash", "/local/startup.sh"]
         volumes = [
           ${hoover_snoop2_repo}
           "{% raw %}${meta.liquid_collections}{% endraw %}:/opt/hoover/collections:ro",
@@ -344,7 +344,7 @@ job "hoover" {
       }
       template {
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
           if [ -z "$SNOOP_ES_URL" ] || [ -z "$SNOOP_DB" ]; then
             echo "incomplete configuration!"

--- a/templates/nextcloud-migrate.nomad
+++ b/templates/nextcloud-migrate.nomad
@@ -46,7 +46,7 @@ job "nextcloud-migrate" {
         destination = "local/migrate.sh"
         perms = "755"
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
 
           ${exec_command('nextcloud:nextcloud', 'sudo', '-Eu', 'www-data', 'bash', '/local/setup.sh')}

--- a/templates/nextcloud-periodic.nomad
+++ b/templates/nextcloud-periodic.nomad
@@ -31,7 +31,7 @@ job "nextcloud-periodic" {
       driver = "raw_exec"
 
       config {
-        command = "sh"
+        command = "bash"
         args    = ["local/periodic.sh"]
       }
 
@@ -39,7 +39,7 @@ job "nextcloud-periodic" {
         destination = "local/periodic.sh"
         perms = "755"
         data = <<-EOF
-          #!/bin/sh
+          #!/bin/bash
           set -ex
 
           ${exec_command('nextcloud:nextcloud', 'sudo', '-Eu', 'www-data', 'php', 'occ', 'files:scan', '--all')}

--- a/templates/nextcloud.nomad
+++ b/templates/nextcloud.nomad
@@ -28,7 +28,7 @@ job "nextcloud" {
           "{% raw %}${meta.liquid_volumes}{% endraw %}/nextcloud/nextcloud/themes:/var/www/html/themes",
           "{% raw %}${meta.liquid_collections}{% endraw %}/uploads/data:/var/www/html/data/uploads/files",
         ]
-        args = ["/bin/sh", "-c", "chown -R 33:33 /var/www/html/ && echo chown done && /entrypoint.sh apache2-foreground"]
+        args = ["/bin/bash", "-c", "chown -R 33:33 /var/www/html/ && echo chown done && /entrypoint.sh apache2-foreground"]
         port_map {
           http = 80
         }

--- a/templates/zipkin.nomad
+++ b/templates/zipkin.nomad
@@ -20,7 +20,7 @@ job "zipkin" {
 
       config {
         image = "docker.elastic.co/elasticsearch/elasticsearch:7.5.1"
-        args = ["/bin/sh", "-c", "chown 1000:1000 /usr/share/elasticsearch/data && echo chown done && /usr/local/bin/docker-entrypoint.sh"]
+        args = ["/bin/bash", "-c", "chown 1000:1000 /usr/share/elasticsearch/data && echo chown done && /usr/local/bin/docker-entrypoint.sh"]
         volumes = [
           "{% raw %}${meta.liquid_volumes}{% endraw %}/zipkin/es:/usr/share/elasticsearch/data",
         ]


### PR DESCRIPTION
A script inside a nomad template was using exclusive bash syntax, but it was run with /bin/sh. There were 2 solutions: run it with bash or change the script in accordance to POSIX. I chose the second method.