### PR TITLE
Oauth2 proxy

### DIFF
--- a/docs/Proxy.md
+++ b/docs/Proxy.md
@@ -1,0 +1,18 @@
+# Proxy
+
+Our current proxy is based on `https://github.com/oauth2-proxy/oauth2-proxy` and sets the following environment variable:
+
+Environment variables specific for the liquid provider:
+- `LIQUID_HTTP_PROTOCOL` - must be set to `http` or `https`
+- `LIQUID_DOMAIN` - domain name of the auth provider service, e.g. liquid.example.org 
+
+- `LIQUID_ENABLE_HYPOTHESIS_HEADERS` - if set, sets the X-Forwarded-User header to `acct:USERNAME@LIQUID_DOMAIN` instead of just the username. This is required by Hypothesis only.
+
+Others relevant environment variables for the proxy Docker container:
+
+- `OAUTH2_PROXY_WHITELIST_DOMAINS` - allows domains for redirection after authentication. Prefix domain with a . to allow subdomains, e.g .liquid.example.org
+- `OAUTH2_PROXY_SSL_INSECURE_SKIP_VERIFY` and `OAUTH2_PROXY_SSL_UPSTREAM_INSECURE_SKIP_VERIFY` are both set to true to skip validation of certificates when using  HTTPS providers and HTTPS upstreams, in case the domain has no valid certificate.
+- `OAUTH2_PROXY_SET_XAUTHREQUEST` set X-Auth-Request-User, used for Hypothesis.
+
+- ` OAUTH2_PROXY_COOKIE_HTTPONLY and OAUTH2_PROXY_COOKIE_SECURE` are both disable to allow both http and https cookies.
+- ` OAUTH2_PROXY_EMAIL_DOMAINS` is set to * to allow any email domain to authenticate.

--- a/liquid_node/commands.py
+++ b/liquid_node/commands.py
@@ -25,22 +25,22 @@ CORE_AUTH_APPS = [
     {
         'name': 'authdemo',
         'vault_path': 'liquid/authdemo/auth.oauth2',
-        'callback': f'{config.app_url("authdemo")}/__auth/callback',
+        'callback': f'{config.app_url("authdemo")}/oauth2/callback',
     },
     {
         'name': 'hoover',
         'vault_path': 'liquid/hoover/auth.oauth2',
-        'callback': f'{config.app_url("hoover")}/__auth/callback',
+        'callback': f'{config.app_url("hoover")}/oauth2/callback',
     },
     {
         'name': 'dokuwiki',
         'vault_path': 'liquid/dokuwiki/auth.oauth2',
-        'callback': f'{config.app_url("dokuwiki")}/__auth/callback',
+        'callback': f'{config.app_url("dokuwiki")}/oauth2/callback',
     },
     {
         'name': 'rocketchat-authproxy',
         'vault_path': 'liquid/rocketchat/auth.oauth2',
-        'callback': f'{config.app_url("rocketchat")}/__auth/callback',
+        'callback': f'{config.app_url("rocketchat")}/oauth2/callback',
     },
     {
         'name': 'rocketchat-app',
@@ -50,7 +50,7 @@ CORE_AUTH_APPS = [
     {
         'name': 'nextcloud',
         'vault_path': 'liquid/nextcloud/auth.oauth2',
-        'callback': f'{config.app_url("nextcloud")}/__auth/callback',
+        'callback': f'{config.app_url("nextcloud")}/oauth2/callback',
     },
     {
         'name': 'codimd-app',
@@ -60,12 +60,12 @@ CORE_AUTH_APPS = [
     {
         'name': 'codimd-authproxy',
         'vault_path': 'liquid/codimd/auth.oauth2',
-        'callback': f'{config.app_url("codimd")}/__auth/callback',
+        'callback': f'{config.app_url("codimd")}/oauth2/callback',
     },
     {
         'name': 'hypothesis',
         'vault_path': 'liquid/hypothesis/auth.oauth2',
-        'callback': f'{config.app_url("hypothesis")}/__auth/callback',
+        'callback': f'{config.app_url("hypothesis")}/oauth2/callback',
     },
 ]
 
@@ -211,6 +211,74 @@ def check_system_config():
         'the "vm.max_map_count" kernel parameter is too low, check readme'
 
 
+def start_job(job, hcl):
+    log.info('Starting %s...', job)
+    spec = nomad.parse(hcl)
+    nomad.run(spec)
+    job_checks = {}
+    for service, checks in nomad.get_health_checks(spec):
+        if not checks:
+            log.warn(f'service {service} has no health checks')
+            continue
+        job_checks[service] = checks
+    return job_checks
+
+
+def populate_secrets(vault_secret_keys, core_auth_apps, liquid_job):
+    """Sets a secrets for every path given and start liquid-core.
+
+    The function sets a secret for every path given (the secrets stored in vault_secret_keys are 256 bits
+    whereas the secrets for cookies are 64 bits long). Then, it starts the liquid-core and creates OAuth2
+    entries for every app. If self-hosted continuous integration is enabled, then the client id and secret
+    areadded to vault.
+
+    Args:
+        vault_secrets_keys: A list of paths for which a secret is needed.
+        core_auth_apps: A list of dictionary which contains app's name, vault_path and callback to create
+                        Oauth2 entries.
+        liquid_job: The template for the "core job", which is the first to start after secrets are set.
+
+    Returns:
+        None
+    """
+
+    for path in vault_secret_keys:
+        ensure_secret_key(path)
+
+    if config.ci_enabled:
+        vault.set('liquid/ci/drone.github', {
+            'client_id': config.ci_github_client_id,
+            'client_secret': config.ci_github_client_secret,
+            'user_filter': config.ci_github_user_filter,
+        })
+        vault.set('liquid/ci/drone.docker', {
+            'username': config.ci_docker_username,
+            'password': config.ci_docker_password,
+        })
+
+    ensure_secret('liquid/rocketchat/adminuser', lambda: {
+        'username': 'rocketchatadmin',
+        'pass': random_secret(64),
+    })
+
+    for name in config.ALL_APPS:
+        ensure_secret(f'liquid/{name}/cookie', lambda: {
+            'cookie': random_secret(64),
+        })
+
+    # Start liquid-core in order to setup the auth
+    liquid_checks = start_job('liquid', liquid_job)
+    wait_for_service_health_checks({'core': liquid_checks['core']})
+
+    # Create the OAuth2 callbacks for apps
+    for app in core_auth_apps:
+        log.info('Auth %s -> %s', app['name'], app['callback'])
+        cmd = ['./manage.py', 'createoauth2app', app['name'], app['callback']]
+        output = retry()(docker.exec_)('liquid:core', *cmd)
+        tokens = json.loads(output)
+        vault.set(app['vault_path'], tokens)
+
+
 @liquid_commands.command()
 @click.option('--no-secrets', 'secrets', is_flag=True, default=True)
 @click.option('--no-checks', 'checks', is_flag=True, default=True)
@@ -254,52 +322,10 @@ def deploy(secrets, checks):
         vault_secret_keys += list(job.vault_secret_keys)
         core_auth_apps += list(job.core_auth_apps)
 
-    if secrets:
-        for path in vault_secret_keys:
-            ensure_secret_key(path)
-
-        if config.ci_enabled:
-            vault.set('liquid/ci/drone.github', {
-                'client_id': config.ci_github_client_id,
-                'client_secret': config.ci_github_client_secret,
-                'user_filter': config.ci_github_user_filter,
-            })
-            vault.set('liquid/ci/drone.docker', {
-                'username': config.ci_docker_username,
-                'password': config.ci_docker_password,
-            })
-
-    def start(job, hcl):
-        log.info('Starting %s...', job)
-        spec = nomad.parse(hcl)
-        nomad.run(spec)
-        job_checks = {}
-        for service, checks in nomad.get_health_checks(spec):
-            if not checks:
-                log.warn(f'service {service} has no health checks')
-                continue
-            job_checks[service] = checks
-        return job_checks
-
     jobs = [(job.name, get_job(job.template)) for job in config.enabled_jobs]
 
-    ensure_secret('liquid/rocketchat/adminuser', lambda: {
-        'username': 'rocketchatadmin',
-        'pass': random_secret(64),
-    })
-
-    # Start liquid-core in order to setup the auth
-    liquid_checks = start('liquid', dict(jobs)['liquid'])
-    if checks:
-        wait_for_service_health_checks({'core': liquid_checks['core']})
-
     if secrets:
-        for app in core_auth_apps:
-            log.info('Auth %s -> %s', app['name'], app['callback'])
-            cmd = ['./manage.py', 'createoauth2app', app['name'], app['callback']]
-            output = retry()(docker.exec_)('liquid:core', *cmd)
-            tokens = json.loads(output)
-            vault.set(app['vault_path'], tokens)
+        populate_secrets(vault_secret_keys, core_auth_apps, dict(jobs)['liquid'])
 
     # check if there are jobs to stop
     nomad_jobs = set(job['ID'] for job in nomad.jobs())
@@ -316,7 +342,7 @@ def deploy(secrets, checks):
 
     health_checks = {}
     for job, hcl in deps_jobs:
-        job_checks = start(job, hcl)
+        job_checks = start_job(job, hcl)
         health_checks.update(job_checks)
 
     # wait until all deps are healthy
@@ -329,7 +355,7 @@ def deploy(secrets, checks):
         retry()(docker.exec_)('hoover-deps:snoop-pg', 'sh', '/local/set_pg_password.sh')
 
     for job, hcl in jobs:
-        job_checks = start(job, hcl)
+        job_checks = start_job(job, hcl)
         health_checks.update(job_checks)
 
     # Wait for everything else

--- a/liquid_node/configuration.py
+++ b/liquid_node/configuration.py
@@ -17,7 +17,7 @@ def split_lang_codes(option):
 
 class Configuration:
     ALL_APPS = ('hoover', 'dokuwiki', 'rocketchat', 'nextcloud',
-                'hypothesis', 'codimd')
+                'hypothesis', 'codimd',)
     # The core apps can't be turned off.
     CORE_APPS = ('liquid', 'hoover',)
 

--- a/repos/repos.sh
+++ b/repos/repos.sh
@@ -3,7 +3,6 @@ repos=(
         liquidinvestigations/hoover-search
         liquidinvestigations/hoover-ui
         liquidinvestigations/core
-        liquidinvestigations/authproxy
         liquidinvestigations/hypothesis-h
         liquidinvestigations/codimd-server
         liquidinvestigations/h-client

--- a/templates/_lib.hcl
+++ b/templates/_lib.hcl
@@ -32,7 +32,7 @@ ephemeral_disk {
 }
 {%- endmacro %}
 
-{%- macro authproxy_group(name, host, upstream, threads=24, memory=300, user_header_template="{}", count=1) %}
+{%- macro authproxy_group(name, host, upstream, threads=24, memory=300, hypothesis_user_header = false) %}
   group "authproxy" {
     ${ group_disk() }
     spread { attribute = {% raw %}"${attr.unique.hostname}"{% endraw %} }
@@ -43,8 +43,6 @@ ephemeral_disk {
       delay = "20s"
       mode = "delay"
     }
-
-    count = ${count}
 
     task "authproxy-web" {
       ${ task_logs() }
@@ -67,23 +65,38 @@ ephemeral_disk {
         port_map {
           authproxy = 5000
         }
+        
         memory_hard_limit = ${memory * 10}
       }
       template {
         data = <<-EOF
-          CONSUL_URL = ${consul_url|tojson}
-          UPSTREAM_SERVICE = ${upstream|tojson}
-          DEBUG = {{key "liquid_debug" | toJSON }}
-          USER_HEADER_TEMPLATE = ${user_header_template|tojson}
-          LIQUID_CORE_SERVICE = "core"
-          LIQUID_PUBLIC_URL = "${config.liquid_http_protocol}://{{key "liquid_domain"}}"
-          {{- with secret "liquid/${name}/auth.django" }}
-            SECRET_KEY = {{.Data.secret_key | toJSON }}
-          {{- end }}
           {{- with secret "liquid/${name}/auth.oauth2" }}
-            LIQUID_CLIENT_ID = {{.Data.client_id | toJSON }}
-            LIQUID_CLIENT_SECRET = {{.Data.client_secret | toJSON }}
+            OAUTH2_PROXY_CLIENT_ID = {{.Data.client_id | toJSON }}
+            OAUTH2_PROXY_CLIENT_SECRET = {{.Data.client_secret | toJSON }}
           {{- end }}
+          {{- with secret "liquid/${name}/cookie" }}
+            OAUTH2_PROXY_COOKIE_SECRET = {{.Data.cookie | toJSON }}
+          {{- end }}
+          OAUTH2_PROXY_EMAIL_DOMAINS = *
+          OAUTH2_PROXY_HTTP_ADDRESS = "0.0.0.0:5000"
+          OAUTH2_PROXY_PROVIDER = "liquid"
+          {{- range service "core" }}
+            OAUTH2_PROXY_REDEEM_URL = "http://{{.Address}}:{{.Port}}/o/token/"
+            OAUTH2_PROXY_PROFILE_URL = "http://{{.Address}}:{{.Port}}/accounts/profile"
+          {{- end }}
+          {{- range service "${upstream}" }} 
+            OAUTH2_PROXY_UPSTREAMS="http://{{.Address}}:{{.Port}}"
+          {{- end }}
+          OAUTH2_PROXY_REDIRECT_URL = "${config.app_url(name)}/oauth2/callback"
+          OAUTH2_PROXY_SKIP_PROVIDER_BUTTON = true
+          OAUTH2_PROXY_SET_XAUTHREQUEST = true
+          OAUTH2_PROXY_WHITELIST_DOMAINS = ".${config.liquid_domain}"
+          OAUTH2_PROXY_REVERSE_PROXY = true
+          {%- if hypothesis_user_header %}
+            LIQUID_ENABLE_HYPOTHESIS_HEADERS = true
+          {%- endif %}
+          LIQUID_DOMAIN = ${config.liquid_domain}
+          LIQUID_HTTP_PROTOCOL = ${config.liquid_http_protocol}
           THREADS = ${threads}
           EOF
         destination = "local/docker.env"
@@ -105,12 +118,12 @@ ephemeral_disk {
           "traefik.frontend.rule=Host:${host}",
         ]
         check {
-          name = "http"
+          name = "ping"
           initial_status = "critical"
           type = "http"
-          path = "/__auth/logout"
-          interval = "6s"
-          timeout = "3s"
+          path = "/ping"
+          interval = "${check_interval}"
+          timeout = "${check_timeout}"
         }
         check_restart {
           limit = 3

--- a/templates/dokuwiki.nomad
+++ b/templates/dokuwiki.nomad
@@ -30,6 +30,7 @@ job "dokuwiki" {
       }
       env {
         LIQUID_CORE_URL = ${config.liquid_core_url|tojson}
+        LIQUID_CORE_LOGOUT_URL = "${config.liquid_core_url}/accounts/logout/?next=/"
         LIQUID_TITLE = ${config.liquid_title|tojson}
         LIQUID_DOMAIN = ${config.liquid_domain|tojson}
         LIQUID_HTTP_PROTOCOL = ${config.liquid_http_protocol|tojson}

--- a/templates/hoover.nomad
+++ b/templates/hoover.nomad
@@ -91,6 +91,7 @@ job "hoover" {
           HOOVER_HYPOTHESIS_EMBED = "${config.liquid_http_protocol}://hypothesis.${config.liquid_domain}/embed.js"
           HOOVER_AUTHPROXY = "true"
           USE_X_FORWARDED_HOST = "true"
+          LIQUID_CORE_LOGOUT_URL = "${config.liquid_core_url}/accounts/logout/?next=/"
           {%- if config.liquid_http_protocol == 'https' %}
             SECURE_PROXY_SSL_HEADER = "HTTP_X_FORWARDED_PROTO"
           {%- endif %}
@@ -138,7 +139,6 @@ job "hoover" {
       upstream='hoover-search',
       threads=50,
       memory=config.hoover_authproxy_memory_limit,
-      count=3,
     ) }
 
   group "snoop-celery-flower" {

--- a/templates/hypothesis.nomad
+++ b/templates/hypothesis.nomad
@@ -386,7 +386,7 @@ job "hypothesis" {
       'hypothesis',
       host='hypothesis.' + liquid_domain,
       upstream='hypothesis',
-      user_header_template="acct:{}@" + liquid_domain,
+      hypothesis_user_header= true,
     ) }
 
   group "client" {

--- a/templates/nextcloud.nomad
+++ b/templates/nextcloud.nomad
@@ -174,7 +174,6 @@ job "nextcloud" {
       upstream='nextcloud-app',
       threads=100,
       memory=850,
-      count=3,
     ) }
 
 }

--- a/templates/rocketchat.nomad
+++ b/templates/rocketchat.nomad
@@ -164,6 +164,5 @@ job "rocketchat" {
       upstream='rocketchat-app',
       threads=50,
       memory=500,
-      count=3,
     ) }
 }

--- a/versions.ini
+++ b/versions.ini
@@ -2,7 +2,7 @@
 codimd = liquidinvestigations/codimd-server:0.2.1
 h-client = liquidinvestigations/h-client:0.1.1
 hoover-search = liquidinvestigations/hoover-search:oauth2-path
-hoover-snoop2 = liquidinvestigations/hoover-snoop2:0.11.1
+hoover-snoop2 = liquidinvestigations/hoover-snoop2:0.11.2
 hoover-ui = liquidinvestigations/hoover-ui:0.3.0
 hypothesis-h = liquidinvestigations/hypothesis-h:0.2.1
 liquid-authproxy = liquidinvestigations/oauth-proxy:liquid_provider

--- a/versions.ini
+++ b/versions.ini
@@ -1,11 +1,11 @@
 [versions]
 codimd = liquidinvestigations/codimd-server:0.2.1
 h-client = liquidinvestigations/h-client:0.1.1
-hoover-search = liquidinvestigations/hoover-search:0.5.10
-hoover-snoop2 = liquidinvestigations/hoover-snoop2:0.11.2
+hoover-search = liquidinvestigations/hoover-search:oauth2-path
+hoover-snoop2 = liquidinvestigations/hoover-snoop2:0.11.1
 hoover-ui = liquidinvestigations/hoover-ui:0.3.0
 hypothesis-h = liquidinvestigations/hypothesis-h:0.2.1
-liquid-authproxy = liquidinvestigations/authproxy:0.3.6
+liquid-authproxy = liquidinvestigations/oauth-proxy:liquid_provider
 liquid-core = liquidinvestigations/core:0.3.7
-liquid-dokuwiki = liquidinvestigations/liquid-dokuwiki:0.0.4
+liquid-dokuwiki = liquidinvestigations/liquid-dokuwiki:oauth2_path
 liquid-nextcloud = liquidinvestigations/liquid-nextcloud:0.2.3


### PR DESCRIPTION
Added integration of https://github.com/oauth2-proxy/oauth2-proxy to replace https://github.com/liquidinvestigations/authproxy/ as a proxy for request. It works on all services that we currently have, with one special condition for hypothesis

I have submitted some changes to the following repoos:

Hoover-Search -> https://github.com/liquidinvestigations/hoover-search/pull/179
Dokuwiki -> https://github.com/liquidinvestigations/liquid-dokuwiki/pull/4/
Oauth2 Liquid Provider -> https://github.com/liquidinvestigations/oauth2-proxy/pull/1/

The "count" variable in authproxy_group from templates/_lib.hcl has been removed, as the current proxy doesn't support having multiple upstream with the same path and hopefully fix the problems with the proxy from the past. 

From CRJI/EIC#464 && From CRJI/EIC#465

