### PR TITLE
Run Registry Alongside Drone

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -205,6 +205,13 @@ The `method` is optional. The default value is `link`, while the possible values
 
 When using the `copy` method, the import will take longer.
 
+### Starting a local registry
+
+`templates/drone.nomad` should be running on your Nomad cluster. It provides a local registry
+mirror on port 6665, but dockerd is not using it yet. To enabled it just run `{root}/templates/registry-setup.sh`.
+This will let docker use the local mirror first then it will try the official one if the
+requested image is not present.
+
 ### Debugging
 
 Set the debug flag in `liquid.ini`:

--- a/templates/registry-daemon.json
+++ b/templates/registry-daemon.json
@@ -1,0 +1,4 @@
+{
+    "registry-mirrors": ["http://localhost:6665", "https://registry-1.docker.io"],
+    "insecure-registry": ["localhost:6665"]
+}

--- a/templates/registry-setup.sh
+++ b/templates/registry-setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+cp registry-daemon.json /etc/docker/daemon.json
+systemctl restart docker


### PR DESCRIPTION
TODO check this for validity, don't see drone becoming aware of it.

We also have that other one in cluster that the daemon never uses.

Maybe we move on to k8s and forget about all this.