### PR TITLE
Exchanged link to Hoover-UI setup in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ You can enable debugging, modify code for the applications, and more, see
 [docs/Development.md](docs/Development.md).
 
 To develop hoover-ui locally, see
-[docs/HooverUI.md](docs/HooverUI.md)
+[Hoover Readme](https://github.com/liquidinvestigations/hoover-ui)
 
 To avoid running the cluster locally, you can use Vagrant, see
 [docs/Vagrant.md](docs/Vagrant.md).


### PR DESCRIPTION
closes CRJI/EIC#550

I exchanged the links because I think that's the most recent Documentation on how to set up the UI locally.