### PR TITLE
Update image-classification-service to 0.0.2

### DIFF
--- a/production-versions.ini
+++ b/production-versions.ini
@@ -13,4 +13,4 @@ rocketchat = rocketchat/rocket.chat:3.9.1
 rocketchat-mongo = mongo:4.4
 thumbnail-generator = fpurchess/preview-service@sha256:1c61b92953d809dcb8b8133dc0353ae59449e640197fd4a139c2faa00fe74499
 pdf-preview = thecodingmachine/gotenberg:6
-image-classification = liquidinvestigations/image-classification-service:0.0.1
+image-classification = liquidinvestigations/image-classification-service:0.0.2

--- a/staging-versions.ini
+++ b/staging-versions.ini
@@ -13,4 +13,4 @@ rocketchat = rocketchat/rocket.chat:3.9.1
 rocketchat-mongo = mongo:4.4
 thumbnail-generator = fpurchess/preview-service@sha256:1c61b92953d809dcb8b8133dc0353ae59449e640197fd4a139c2faa00fe74499
 pdf-preview = thecodingmachine/gotenberg:6
-image-classification = liquidinvestigations/image-classification-service:0.0.1
+image-classification = liquidinvestigations/image-classification-service:0.0.2


### PR DESCRIPTION
Version 0.0.1 had to download a file after the container was created (required connection to the internet). In 0.0.2 the download is done during container creation. 
There is also a new status endpoint to get information about the service. 