### PR TITLE
add env to disable dynamic collection admin during startup

### DIFF
--- a/templates/hoover.nomad
+++ b/templates/hoover.nomad
@@ -269,7 +269,7 @@ job "hoover" {
         data = <<-EOF
           #!/bin/bash
           set -e
-
+          export ENABLE_DYNAMIC_COLLECTION_ADMINS=True
           for i in $(seq 1 10000); do
             date
             echo "/runserver retry=$i"


### PR DESCRIPTION
required for this: https://github.com/liquidinvestigations/hoover-snoop2/pull/488